### PR TITLE
Fix dismiss issues

### DIFF
--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
@@ -1191,11 +1191,11 @@ public class SpotlightView extends FrameLayout {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (dismissOnBackPress) {
-            if (event.getAction() == KeyEvent.ACTION_UP && event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+        if (dismissOnBackPress && event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+            if (event.getAction() == KeyEvent.ACTION_UP) {
                 dismiss();
-                return true;
             }
+            return true;
         }
         return super.dispatchKeyEvent(event);
     }

--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
@@ -408,6 +408,9 @@ public class SpotlightView extends FrameLayout {
         });
 
         setVisibility(View.VISIBLE);
+        if (dismissOnBackPress) {
+            requestFocus();
+        }
         anim.start();
     }
 
@@ -475,6 +478,9 @@ public class SpotlightView extends FrameLayout {
         });
 
         setVisibility(VISIBLE);
+        if (dismissOnBackPress) {
+            requestFocus();
+        }
         startAnimation(fadeIn);
     }
 

--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
@@ -185,6 +185,8 @@ public class SpotlightView extends FrameLayout {
     private Typeface mTypeface = null;
 
     private int softwareBtnHeight;
+    
+    private boolean dismissCalled = false;
 
 
     public SpotlightView(Context context) {
@@ -347,6 +349,11 @@ public class SpotlightView extends FrameLayout {
      * Dissmiss view with reverse animation
      */
     private void dismiss() {
+        if (dismissCalled) {
+            return;
+        }
+        dismissCalled = true;
+        
         preferencesManager.setDisplayed(usageId);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (isRevealAnimationEnabled)


### PR DESCRIPTION
These changes some some issues that I found while using a sequence.
The main one involved just tapping the spotlight view multiple times. Because `dismiss` was called for each tap, the animation spazzed out and the `onUserClicked` callback was triggered multiple times, breaking the sequence badly.

Another issue could occur when focus was lost between views of a sequence. Since `requestFocus()` was only called before the view was visible, it didn't actually seem to do anything. By calling it right after the view is set visible, focus is actually granted, and the back button functions properly.